### PR TITLE
wordlist_v3: Fix codes for d+ and d- words

### DIFF
--- a/src/wordlist_v3.c
+++ b/src/wordlist_v3.c
@@ -250,10 +250,10 @@ char *wordlist_v3[MAX_BUILTIN_WORDS] = {
 /* d3 */    ",",                        /* ( n -- ) */
 /* d4 */    "um*",                      /* ( u1_32 u2_32 -- product_64 ) */
 /* d5 */    "um/mod",                   /* ( u1_64 u2_32 -- remainder_32 quot_32 ) */
-/* d6 */    "d+",                       /* ( x1 x2 -- x3 ) */
-/* d7 */    "d-",                       /* ( x1 x2 -- x3 ) */
-/* d8 */    NULL,
-/* d9 */    NULL,
+/* d6 */    NULL,
+/* d7 */    NULL,
+/* d8 */    "d+",                       /* ( x1 x2 -- x3 ) */
+/* d9 */    "d-",                       /* ( x1 x2 -- x3 ) */
 /* da */    "get-token",                /* XXX */
 /* db */    "set-token",                /* XXX */
 /* dc */    "state",                    /* XXX */


### PR DESCRIPTION
These are wrong, possibly typoes. Checked against the Sun [1] manual.

[1] Sun Microsystems, Inc., Writing FCode 3.x Programs
    (Part No.  806-1379-10, February 2000, Revision 01)
    pp. 288-289, 405, 438, 452
    <https://docs.oracle.com/cd/E63648_01/pdf/806-1379.pdf>