### PR TITLE
cli: Fix argument parsing on GNU

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
 
     cmd = basename(argv[0]);
 
-    while ( (c = getopt(argc, argv, "hv")) != -1 ) {
+    while ( (c = getopt(argc, argv, "+hv")) != -1 ) {
         switch (c) {
         case 'v':
             fprintf(stderr,
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
 
         optind++;
 
-        while ( (c = getopt(argc, argv, "23o:")) != -1 ) {
+        while ( (c = getopt(argc, argv, "+23o:")) != -1 ) {
             switch (c) {
             case '2':
                 fcode_version = 2;
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
 
         optind++;
 
-        while ( (c = getopt(argc, argv, "o:")) != -1 ) {
+        while ( (c = getopt(argc, argv, "+o:")) != -1 ) {
             switch (c) {
             case 'o':
                 output = optarg;


### PR DESCRIPTION
The command line tool assumes getopt(3) parses the arguments in order. However, the GNU libc first permutes argv[] so that non-options (such as "detokenize") are at the end.

The GNU getopt(3) can be forced into compatible mode either via POSIXLY_CORRECT environment variable, or by starting the optstring with a '+'. Let's do the latter -- it seems to not cause trouble on SunOS either.

Tested on the following:
1.) Fedora Linux 40, x86_64
2.) SunOS sunos 5.11 tribblix-m34 i86pc i386 i86pc